### PR TITLE
close #12 OpenBadge email検証の実装

### DIFF
--- a/lib/openbadge.ts
+++ b/lib/openbadge.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import axios from "axios";
 const pngitxt = require("png-itxt");
 const Through = require("stream").PassThrough;
@@ -21,7 +22,18 @@ export const extractOpenBadgeMetadataFromImage = (imageString: string) => {
   });
 };
 
-export const validateOpenBadge = async (openBadgeMetadata: any) => {
+export const validateOpenBadge = async (
+  email: string,
+  openBadgeMetadata: any
+) => {
+  const [, expectedEmailHash] = openBadgeMetadata.recipient.identity.split("$");
+  const inputEmailHash = crypto
+    .createHash("sha256")
+    .update(email)
+    .digest("hex");
+  if (inputEmailHash !== expectedEmailHash) {
+    return false;
+  }
   const { data } = await axios.post(
     openBadgeVerifierURL,
     {

--- a/lib/vc.ts
+++ b/lib/vc.ts
@@ -68,7 +68,8 @@ export const prepareIssueRequest = async (
 
 export const issueRequest = async (
   manifestId: string,
-  openBadgeMetadata: any
+  openBadgeMetadata: any,
+  email: string
 ) => {
   // TODO:
   // manifestとアクセストークンを元にazureにリクエストを投げる
@@ -94,7 +95,9 @@ export const issueRequest = async (
   // openbadge
   const { data } = await axios.get(openBadgeMetadata.badge);
 
+  issuanceConfig.issuance.claims.email = email;
   issuanceConfig.issuance.claims.openbadge = JSON.stringify(data);
+
   issuanceConfig.registration.clientName = clientName;
   issuanceConfig.authority = authority;
   issuanceConfig.callback.url = `${host}api/issuer/issuance-request-callback`;

--- a/pages/api/issuer/issuance-request.ts
+++ b/pages/api/issuer/issuance-request.ts
@@ -16,16 +16,22 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Data>
 ) {
-  const base64ImageWithoutPrefix = req.body.file.split(",")[1];
+  const { email, file } = req.body;
+  const base64ImageWithoutPrefix = file.split(",")[1];
   const openBadgeMetadata = await extractOpenBadgeMetadataFromImage(
     base64ImageWithoutPrefix
   );
-  const result = await validateOpenBadge(openBadgeMetadata);
+  const result = await validateOpenBadge(email, openBadgeMetadata);
   if (!result) {
     throw new Error("OpenBadge invalid");
   }
+
   const manifestURL = await prepareIssueRequest(openBadgeMetadata);
-  const { pin, url } = await issueRequest(manifestURL, openBadgeMetadata);
+  const { pin, url } = await issueRequest(
+    manifestURL,
+    openBadgeMetadata,
+    email
+  );
   res.status(200).json({
     pin,
     url,

--- a/pages/issue.tsx
+++ b/pages/issue.tsx
@@ -10,6 +10,7 @@ import {
   Heading,
   Flex,
   Image,
+  Input,
   Spinner,
 } from "@chakra-ui/react";
 import { WarningIcon, CheckCircleIcon } from "@chakra-ui/icons";
@@ -21,14 +22,20 @@ const Home: NextPage = () => {
     "initial" | "loading" | "verified" | "failed"
   >("initial");
 
+  const [email, setEmail] = React.useState("");
   const [image, setImage] = React.useState("");
   const [url, setUrl] = React.useState("");
+
+  const handleEmailChain = (e: any) => {
+    setEmail(e.target.value);
+  };
 
   const uploadOpenBadge = async (event: any) => {
     event.preventDefault();
     setStatus("loading");
     axios
       .post("/api/issuer/issuance-request", {
+        email,
         file: image,
       })
       .then(function (response) {
@@ -72,6 +79,13 @@ const Home: NextPage = () => {
             <Text>Input your OpenBadge png/svg</Text>
             <Box my="8">
               <form onSubmit={uploadOpenBadge}>
+                <Input
+                  mb="8"
+                  value={email}
+                  placeholder="email"
+                  onChange={handleEmailChain}
+                />
+
                 <input
                   type="file"
                   name="image"


### PR DESCRIPTION
- email入力欄の追加
- openbadgeのemailの検証
- 検証したemailをvcにセット

- type emailのみ対応のため、phone numberなどは今回スコープ外としています
<img width="631" alt="Screen Shot 2022-01-29 at 16 46 32" src="https://user-images.githubusercontent.com/38043569/151652572-20d237a5-c797-41d1-ae32-3ee5d8f7c499.png">

![IMG_2116](https://user-images.githubusercontent.com/38043569/151652581-31d01d83-fd8e-439d-82f5-9970e52086b4.PNG)

